### PR TITLE
Fix a bug where if the contents change then it didnt update the UI

### DIFF
--- a/src/multiselect.html
+++ b/src/multiselect.html
@@ -187,6 +187,7 @@
 
     (function() {
         var multiselectPrototype = Object.create(HTMLElement.prototype);
+        console.log("Hello");
 
         /* Items property accessor */
         Object.defineProperty(multiselectPrototype, 'items', {
@@ -214,6 +215,19 @@
             this._field = this._root.querySelector('.multiselect-field');
             this._popup = this._root.querySelector('.multiselect-popup');
             this._list = this._root.querySelector('.multiselect-list');
+
+            var _this = this;
+            var observer = new MutationObserver(function(mutations) {
+                _this._root = _this.createRootElement();
+                _this._control = _this._root.querySelector('.multiselect');
+                _this._field = _this._root.querySelector('.multiselect-field');
+                _this._popup = _this._root.querySelector('.multiselect-popup');
+                _this._list = _this._root.querySelector('.multiselect-list');
+
+                _this.render();
+
+            });
+            observer.observe(this, { childList: true });
         };
 
         multiselectPrototype.initOptions = function() {


### PR DESCRIPTION
This pull request solves this problem.

You should use a MutationObserver
https://developer.mozilla.org/en/docs/Web/API/MutationObserver

If the contents of the web component changes, for example the

```
        <li value="1" selected>Item 1</li>
        <li value="2">Item 2</li>
        <li value="3" selected>Item 3</li>
        <li value="4">Item 4</li>

```

If I used Javascript to change the contents of this to

```
        <li value="1" selected>Item 1</li>
        <li value="2">Item 2</li>

```

Then it should update the displayed data again. So if I use javascript to change the contents then it should update again.